### PR TITLE
Added Travis CI/CD, added Bintray Distribution Channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/.idea/
+*.iml
 /target/
 /.settings/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+script: mvn clean verify
+deploy:
+  provider: bintray
+  file: "target/.travis/bintray.json"
+  user: "${BINTRAY_USER}"
+  key: "${BINTRAY_KEY}"
+  skip_cleanup: true

--- a/.travis/bintray.json
+++ b/.travis/bintray.json
@@ -1,0 +1,24 @@
+{
+    "package": {
+        "subject": "${bintray.subject}",
+        "repo": "${bintray.repo}",
+        "name": "${project.artifactId}"
+    },
+    "version": {
+        "name": "${project.version}",
+        "released": "${maven.build.timestamp}",
+        "vcs_tag": "${project.version}",
+        "gpgSign": false
+    },
+    "files": [
+        {
+            "includePattern": "pom.xml",
+            "uploadPattern": "${bintray.root}/${project.version}/${project.artifactId}-${project.version}.pom"
+        },
+        {
+            "includePattern": "${project.build.directory}/(.*\.jar)",
+            "uploadPattern": "${bintray.root}/${project.version}/$1"
+        }
+    ],
+    "publish": true
+}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,20 @@ be created automaticly.
 Installation
 ============
 
-Currently the maven plugin is not published to maven central, so it
-needs to be installed into the local repository. To do this, run:
+Currently the maven plugin is not published to maven central.
+You may add the following repository to your Plugin Repositories in order
+to download a pre packaged distribution.
+```
+<pluginRepositories>
+    <pluginRepository>
+        <id>TlbCodeGenerator</id>
+        <name>TlbCodeGenerator</name>
+        <url>https://dl.bintray.com/bjoernakamanf/Qwertzimus</url>
+    </pluginRepository>
+</pluginRepositories>
+```
+
+Alternatively you may install it into the local repository. To do this, run:
 
 ```
 mvn install

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[ ![Download](https://api.bintray.com/packages/bjoernakamanf/Qwertzimus/TlbCodeGenerator/images/download.svg) ](https://bintray.com/bjoernakamanf/Qwertzimus/TlbCodeGenerator/_latestVersion)
+[![Build Status](https://travis-ci.com/BjoernAkAManf/TlbCodeGenerator.svg?branch=master)](https://travis-ci.com/BjoernAkAManf/TlbCodeGenerator) 
+
 TlbCodeGenerator is a code generator for COM libraries. Based on the
 type library information, bindings for many COM based libraries can
 be created automaticly.

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.doppel_helix.jna.tlbcodegenerator</groupId>
     <artifactId>TlbCodeGenerator</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>maven-plugin</packaging>
-    
+
+    <distributionManagement>
+        <repository>
+            <id>bt-bjoernakamanf-releases</id>
+            <name>bjoernakamanf-Qwertzimus</name>
+            <url>https://api.bintray.com/maven/${bintray.subject}/${bintray.repo}/${project.artifactId}/;publish=1</url>
+        </repository>
+    </distributionManagement>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <bintray.subject>bjoernakamanf</bintray.subject>
+        <bintray.repo>Qwertzimus</bintray.repo>
+        <bintray.root>eu/doppel_helix/jna/tlbcodegenerator/TlbCodeGenerator</bintray.root>
     </properties>
 
     <dependencies>
@@ -45,9 +57,22 @@
             <version>4.3.0</version>
         </dependency>
     </dependencies>
-    
+
     <build>
+        <resources>
+            <resource>
+                <directory>.travis</directory>
+                <targetPath>${project.build.directory}/.travis</targetPath>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
+            <!-- 3.X required due to https://issues.apache.org/jira/browse/MRESOURCES-99 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>


### PR DESCRIPTION
Hi,

first of all: Great Work, have been using your Bindings for several automization Scripts.
Since this generator has yet to be published to any maven repository, it's a pain to download and distribute between collegues.

Before merging / implementing the following things need to be established:
- A free Travis account (For Travis to Work)
- A free bintray account (Storage)
- Configuring Travis correctly (Setting Travis BINTRAY_USER / BINTRAY_KEY to your Username and API-Key respectively.)
- Badges / URL's should then be adjusted to your accounts respectively.

This should reduce work required by users. It shouldn't require much maintenance by you either.
Compared to Maven Central, this is easy to support fast.

If you require any further information, let me know.